### PR TITLE
using path.root for naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 ## Module Parameters
 
 #### Required
-* project: Used for Droplet names in DigitalOcean
-* region: data center to use for deployment
-* keys: ssh key ids stored in DigitalOcean's system. Retrievable through API
-* private_key_path: commonly /home/user/.ssh/id_rsa
-* ssh_fingerprint: md5 ssh key fingerprint
-* public_key: id_rsa.pub contents
-* ansible_user: username which will be used by ansible to connect to remote hosts
+* project
+* region
+* keys
+* private_key_path
+* ssh_fingerprint
+* public_key
+* ansible_user
 
 #### Optional
-* db_node_count -> *(default = 3)*
+* db_node_count -> *(default = 3. Recommended value is 5 for production)*
 * db_node_size -> *(default = 4gb)*
 * lb_size -> *(default = 4gb)*
 * image_slug -> *(default = ubuntu-16-04-x64)*
@@ -22,8 +22,8 @@
 #### main.tf
 
     module "galera-cluster" {
-      source           = "github.com/cmndrsp0ck/galera-tf-mod.git?ref=v1.0.2"
-      db_node_count    = "3"
+      source           = "git::git@bitbucket.org:cmndrsp0ck/galera-cluster.git?ref=v1.0.0"
+      db_node_count    = "5"
       db_node_size     = "16gb"
       lb_size          = "c-2"
       project          = "${var.project}"
@@ -34,3 +34,5 @@
       public_key       = "${var.public_key}"
       ansible_user     = "${var.ansible_user}"
     }
+
+**note**: The module *source* path used depends on how you've set up your directory structure.

--- a/tags.tf
+++ b/tags.tf
@@ -1,5 +1,5 @@
 resource "digitalocean_tag" "env_tag" {
-  name = "${terraform.workspace}"
+  name = "${basename(path.root)}"
 }
 
 resource "digitalocean_tag" "project_tag" {
@@ -12,10 +12,6 @@ resource "digitalocean_tag" "resource_role1" {
 
 resource "digitalocean_tag" "resource_role2" {
   name = "database-loadbalancer"
-}
-
-resource "digitalocean_tag" "resource_role3" {
-  name = "async-slave"
 }
 
 resource "digitalocean_tag" "add_tag" {

--- a/variables.tf
+++ b/variables.tf
@@ -14,11 +14,6 @@ variable "lb_size" {
   default = "c-2"
 }
 
-variable "db_async_count" {
-  type    = "string"
-  default = "1"
-}
-
 variable "project" {}
 
 variable "region" {}
@@ -37,12 +32,3 @@ variable "ssh_fingerprint" {}
 variable "public_key" {}
 
 variable "ansible_user" {}
-
-# module outputs
-output "loadbalancer_tag" {
-  value = "${digitalocean_tag.resource_role2.name}"
-}
-
-output "database_tag" {
-  value = "${digitalocean_tag.resource_role1.name}"
-}


### PR DESCRIPTION
Using directory structure for environment isolation so I'm switching up the naming for resources to use `${basename(path.root)}` instead of `${terraform.workspace}`.